### PR TITLE
Update swagger.json

### DIFF
--- a/api/swagger.json
+++ b/api/swagger.json
@@ -71,7 +71,7 @@
         }
       }
     },
-    "/user": {
+    "/users": {
       "post": {
         "summary": "Register a new user",
         "description": "Register a new user",
@@ -104,7 +104,9 @@
             }
           }
         }
-      },
+      }
+    },
+    "/user": {
       "get": {
         "summary": "Get current user",
         "description": "Gets the currently logged-in user",


### PR DESCRIPTION
In the current version registration of the use is located at `/api/user`. As specs state it should be at `/api/users`.